### PR TITLE
修复 #14 ，更换 AssetManifest API

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -187,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: "direct main"
     description:
@@ -375,10 +375,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/sqlite3_simple.dart
+++ b/lib/src/sqlite3_simple.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
 
@@ -19,8 +18,8 @@ typedef OpenSimple = DynamicLibrary? Function();
 
 extension Sqlite3SimpleEx on Sqlite3 {
   /// 加载 Simple 扩展，请在打开数据库前调用。如果需要结巴分词功能，调用 [saveJiebaDict]。
-  /// 若希望自行加载 Simple 原生库，向 [overrideOpen] 传入返回值为 [DynamicLibrary] 或 null 的函数，
-  /// 返回值非 null 时，优先使用返回值加载扩展，反之使用默认的加载逻辑。
+  /// 若希望自行加载 Simple 原生库，向 [overrideOpen] 传入返回值为 `DynamicLibrary?` 的函数，
+  /// 返回值非空时，优先使用返回值加载扩展，反之使用默认的加载逻辑。
   void loadSimpleExtension({OpenSimple? overrideOpen}) {
     DynamicLibrary defaultOpen() {
       String libSimple = "";
@@ -53,9 +52,8 @@ extension Sqlite3SimpleEx on Sqlite3 {
   }) async {
     // CppJieba通过文件路径读取字典，需要将字典文件保存到本地以供读取
     // https://github.com/yanyiwu/cppjieba/blob/391121d5db0f31dd5ce9795d4d34812f20eeb25c/include/cppjieba/DictTrie.hpp#L211 )
-    final jsonString = await rootBundle.loadString("AssetManifest.json");
-    final pathList = Map<String, dynamic>.from(json.decode(jsonString))
-        .keys
+    final assetManifest = await AssetManifest.loadFromAssetBundle(rootBundle);
+    final pathList = assetManifest.listAssets()
         .where((e) =>
             e.startsWith("packages/sqlite3_simple") &&
             e.contains("cpp_jieba_dict") &&

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/SageMik/sqlite3_simple
 
 environment:
   sdk: '>=3.4.0 <4.0.0'
-  flutter: '>=3.3.0'
+  flutter: '>=3.22.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
目前 Flutter [计划移除 `AssetManifest.json`](https://docs.flutter.cn/release/breaking-changes/asset-manifest-dot-json)，迁移至  AssetManifest API 以进行兼容。